### PR TITLE
add checking if index 4 on message exist

### DIFF
--- a/LogentriesTarget.php
+++ b/LogentriesTarget.php
@@ -65,7 +65,7 @@ class LogentriesTarget extends Target
                 $monolog->addRecord(
                     $this->_monologLevels[$message[1]],
                     $this->formatMessage($message),
-                    is_array($message[4]) ? $message[4] : []
+                    isset($message[4]) && is_array($message[4]) ? $message[4] : []
                 );
             }
         }


### PR DESCRIPTION
I encountered an issue where logentries is being disabled. The reason is the target class throws an error because index 4 on $message don't exist.
